### PR TITLE
Fix noflip events and Encoding Quality fix

### DIFF
--- a/Magma/MainForm.Designer.cs
+++ b/Magma/MainForm.Designer.cs
@@ -4661,9 +4661,9 @@ namespace MagmaC3
             this.EncodingQualityUpDown.Items.Add("08");
             this.EncodingQualityUpDown.Items.Add("07");
             this.EncodingQualityUpDown.Items.Add("06");
-            this.EncodingQualityUpDown.Items.Add("05");
+            this.EncodingQualityUpDown.Items.Add("05 (default)");
             this.EncodingQualityUpDown.Items.Add("04");
-            this.EncodingQualityUpDown.Items.Add("03 (default)");
+            this.EncodingQualityUpDown.Items.Add("03");
             this.EncodingQualityUpDown.Items.Add("02");
             this.EncodingQualityUpDown.Items.Add("01 (lowest)");
             this.EncodingQualityUpDown.Location = new System.Drawing.Point(390, 507);
@@ -4671,9 +4671,9 @@ namespace MagmaC3
             this.EncodingQualityUpDown.ReadOnly = true;
             this.EncodingQualityUpDown.Size = new System.Drawing.Size(82, 20);
             this.EncodingQualityUpDown.TabIndex = 67;
-            this.EncodingQualityUpDown.Text = "03 (default)";
+            this.EncodingQualityUpDown.Text = "05 (default)";
             this.EncodingQualityUpDown.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.ToolTip.SetToolTip(this.EncodingQualityUpDown, "Set the encoding quality for the audio. Default is 3");
+            this.ToolTip.SetToolTip(this.EncodingQualityUpDown, "Set the encoding quality for the audio. Default is 5");
             this.EncodingQualityUpDown.SelectedItemChanged += new System.EventHandler(this.EncodingQualityUpDown_SelectedItemChanged);
             // 
             // LabelEncodingQuality

--- a/Magma/MainForm.Designer.cs
+++ b/Magma/MainForm.Designer.cs
@@ -4661,9 +4661,9 @@ namespace MagmaC3
             this.EncodingQualityUpDown.Items.Add("08");
             this.EncodingQualityUpDown.Items.Add("07");
             this.EncodingQualityUpDown.Items.Add("06");
-            this.EncodingQualityUpDown.Items.Add("05 (default)");
+            this.EncodingQualityUpDown.Items.Add("05");
             this.EncodingQualityUpDown.Items.Add("04");
-            this.EncodingQualityUpDown.Items.Add("03");
+            this.EncodingQualityUpDown.Items.Add("03 (default)");
             this.EncodingQualityUpDown.Items.Add("02");
             this.EncodingQualityUpDown.Items.Add("01 (lowest)");
             this.EncodingQualityUpDown.Location = new System.Drawing.Point(390, 507);
@@ -4671,9 +4671,9 @@ namespace MagmaC3
             this.EncodingQualityUpDown.ReadOnly = true;
             this.EncodingQualityUpDown.Size = new System.Drawing.Size(82, 20);
             this.EncodingQualityUpDown.TabIndex = 67;
-            this.EncodingQualityUpDown.Text = "05 (default)";
+            this.EncodingQualityUpDown.Text = "03 (default)";
             this.EncodingQualityUpDown.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.ToolTip.SetToolTip(this.EncodingQualityUpDown, "Set the encoding quality for the audio. Default is 5");
+            this.ToolTip.SetToolTip(this.EncodingQualityUpDown, "Set the encoding quality for the audio. Default is 3");
             this.EncodingQualityUpDown.SelectedItemChanged += new System.EventHandler(this.EncodingQualityUpDown_SelectedItemChanged);
             // 
             // LabelEncodingQuality

--- a/Magma/MainForm.cs
+++ b/Magma/MainForm.cs
@@ -1258,8 +1258,8 @@ namespace MagmaC3
                 TextBoxAuthor.Text = DefaultAuthor;
             }
 
-            EncodingQualityUpDown.SelectedItem = wiiConversion.Checked ? "03 (default)" : "03 (default)";
-            EncodingQuality = 3;
+            EncodingQualityUpDown.SelectedItem = wiiConversion.Checked ? "03" : "05 (default)";
+            EncodingQuality = 5;
 
             chkTempo.Checked = !neverCheckForTempoMap.Checked;
             chkDrumsMix.Checked = true;
@@ -1568,17 +1568,6 @@ namespace MagmaC3
             UpdateDifficultyDisplayNEMO(PictureDrumDifficulty1, ProjectFile.RankDrum, true);
 
             doDrumMix();
-
-            if (kick == true || snare == true)
-            {
-                if (EncodingQuality > 3)
-                {
-                    MessageBox.Show("You're currently selecting a mix other than stereo kit.\nEncoding Quality 3 has been automatically selected" +
-                                    "\ndue to issues with playback on the PS3.", mAppTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                    EncodingQualityUpDown.SelectedItem = "03 (default)";
-                    EncodingQuality = 3;
-                }
-            }
         }
 
         private void ButtonDrumKit_Click(object sender, EventArgs e)
@@ -5082,7 +5071,7 @@ namespace MagmaC3
                 MessageBox.Show("You're currently using Wii Mode\nDue to the Wii's limited memory, you are restricted to using\nEncoding Quality 3 " +
                                 "(RBN default) or lower",mAppTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 WiiWarning = true;
-                EncodingQualityUpDown.SelectedItem = "03 (default)";
+                EncodingQualityUpDown.SelectedItem = "03";
                 return;
             }
 
@@ -5095,13 +5084,13 @@ namespace MagmaC3
                 case "02":
                     EncodingQuality = 2;
                     break;
-                case "03 (default)":
+                case "03":
                     EncodingQuality = 3;
                     break;
                 case "04":
                     EncodingQuality = 4;
                     break;
-                case "05":
+                case "05 (default)":
                     EncodingQuality = 5;
                     break;
                 case "06":
@@ -5120,17 +5109,9 @@ namespace MagmaC3
                     EncodingQuality = 10;
                     break;
                 default:
-                    EncodingQuality = 3;
-                    EncodingQualityUpDown.SelectedItem = "03 (default)";
+                    EncodingQuality = 5;
+                    EncodingQualityUpDown.SelectedItem = "05 (default)";
                     break;
-            }
-
-            if (ComboDrums.SelectedIndex > 0 && EncodingQuality > 3)
-            {
-                MessageBox.Show("You've currently selected a mix other than stereo kit.\nEncoding Quality 3 has been automatically selected" +
-                                "\ndue to issues with playback on the PS3.", mAppTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                EncodingQualityUpDown.SelectedItem = "03 (default)";
-                EncodingQuality = 3;
             }
         }
 

--- a/Magma/MainForm.cs
+++ b/Magma/MainForm.cs
@@ -1258,8 +1258,8 @@ namespace MagmaC3
                 TextBoxAuthor.Text = DefaultAuthor;
             }
 
-            EncodingQualityUpDown.SelectedItem = wiiConversion.Checked ? "03" : "05 (default)";
-            EncodingQuality = 5;
+            EncodingQualityUpDown.SelectedItem = wiiConversion.Checked ? "03 (default)" : "03 (default)";
+            EncodingQuality = 3;
 
             chkTempo.Checked = !neverCheckForTempoMap.Checked;
             chkDrumsMix.Checked = true;
@@ -1568,6 +1568,17 @@ namespace MagmaC3
             UpdateDifficultyDisplayNEMO(PictureDrumDifficulty1, ProjectFile.RankDrum, true);
 
             doDrumMix();
+
+            if (kick == true || snare == true)
+            {
+                if (EncodingQuality > 3)
+                {
+                    MessageBox.Show("You're currently selecting a mix other than stereo kit.\nEncoding Quality 3 has been automatically selected" +
+                                    "\ndue to issues with playback on the PS3.", mAppTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    EncodingQualityUpDown.SelectedItem = "03 (default)";
+                    EncodingQuality = 3;
+                }
+            }
         }
 
         private void ButtonDrumKit_Click(object sender, EventArgs e)
@@ -5071,7 +5082,7 @@ namespace MagmaC3
                 MessageBox.Show("You're currently using Wii Mode\nDue to the Wii's limited memory, you are restricted to using\nEncoding Quality 3 " +
                                 "(RBN default) or lower",mAppTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 WiiWarning = true;
-                EncodingQualityUpDown.SelectedItem = "03";
+                EncodingQualityUpDown.SelectedItem = "03 (default)";
                 return;
             }
 
@@ -5084,13 +5095,13 @@ namespace MagmaC3
                 case "02":
                     EncodingQuality = 2;
                     break;
-                case "03":
+                case "03 (default)":
                     EncodingQuality = 3;
                     break;
                 case "04":
                     EncodingQuality = 4;
                     break;
-                case "05 (default)":
+                case "05":
                     EncodingQuality = 5;
                     break;
                 case "06":
@@ -5109,9 +5120,17 @@ namespace MagmaC3
                     EncodingQuality = 10;
                     break;
                 default:
-                    EncodingQuality = 5;
-                    EncodingQualityUpDown.SelectedItem = "05 (default)";
+                    EncodingQuality = 3;
+                    EncodingQualityUpDown.SelectedItem = "03 (default)";
                     break;
+            }
+
+            if (ComboDrums.SelectedIndex > 0 && EncodingQuality > 3)
+            {
+                MessageBox.Show("You've currently selected a mix other than stereo kit.\nEncoding Quality 3 has been automatically selected" +
+                                "\ndue to issues with playback on the PS3.", mAppTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                EncodingQualityUpDown.SelectedItem = "03 (default)";
+                EncodingQuality = 3;
             }
         }
 

--- a/Magma/NemoTools.cs
+++ b/Magma/NemoTools.cs
@@ -862,22 +862,30 @@ namespace MagmaC3
                                 var mix = mixevent.ToString().Substring(index, mixevent.ToString().Length - index);
                                 mix = mix.Replace("easy", ""); //old drum mix no longer used
                                 mix = mix.Replace("nokick", ""); //old drum mix no longer used
-                                mix = mix.Replace("noflip", ""); //old drum mix no longer used
                                 //remove the 3] from the end
                                 var newmix = mix.Substring(0, mix.Length - 2);
                                 var disco = "";
+                                var noflip = "";
                                 if (mix.EndsWith("d]", StringComparison.Ordinal))
                                 {
                                     newmix = mix.Substring(0, mix.Length - 3); //disco flip, remove the 3d] from the end
                                     disco = "d";
+                                    noflip = "";
+                                }
+                                else if (mix.EndsWith("noflip]", StringComparison.Ordinal)) //no-flip disco flip
+                                {
+                                    newmix = mix.Substring(0, mix.Length - 9); //remove the 3dnoflip] from the end
+                                    disco = "d";
+                                    noflip = "noflip";
                                 }
                                 else if (mix.EndsWith("a]", StringComparison.Ordinal)) //found in some HMX-authored songs (Fly Like an Eagle)
                                 {
                                     newmix = mix.Substring(0, mix.Length - 3); //remove the 3a] from the end
                                     disco = "";
+                                    noflip = "";
                                 }
                                 //messy but this way don't have to re-do how this gets called
-                                newmix = newmix + drums_mix_Text.Substring(drums_mix_Text.Length - 2, 1) + disco + "]";
+                                newmix = newmix + drums_mix_Text.Substring(drums_mix_Text.Length - 2, 1) + disco + noflip + "]";
                                 newmixes.Add(new TextEvent(newmix, MetaEventType.TextEvent, mixevent.AbsoluteTime));
                                 removemixes.Add(notes);
                             }


### PR DESCRIPTION
This fixes the issue brought about by Nemo's MIDI validator involving the use of noflip drum events. noflip events will now stay in the MIDI as intended and can be used in RB3.